### PR TITLE
Fixed the function regexp to be more accurate

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -67,7 +67,7 @@ function! GetShIndent()
     if !s:is_case_ended(line)
       let ind += s:indent_value('case-statements')
     endif
-  elseif line =~ '^\s*\<\k\+\>\s*()\s*{' || line =~ '^\s*{' || line =~ '^\s*\%(function\)\?\s*\w\+\s*()'
+  elseif line =~ '^\s*\<\k\+\>\s*()\s*{' || line =~ '^\s*{' || line =~ '^\s*function\s*\k\+\s*\%(()\)\?\s*{'
     if line !~ '}\s*\%(#.*\)\=$'
       let ind += s:indent_value('default')
     endif


### PR DESCRIPTION
The function keyword isn't optional, it's required. The parenthesis are
not required, they are optional. Furthermore we must match till the `{`
if it is to be indented. Also we should use `\k` to match identfiers not `\w`.
