### PR TITLE
Fixes keyword match regex for zsh to match whole word

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -70,7 +70,7 @@ function! GetShIndent()
 
   " Check contents of previous lines
   if line =~ '^\s*\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>' ||
-        \  (&ft is# 'zsh' && line =~ '\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>')
+        \  (&ft is# 'zsh' && line =~ '\<\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>')
     if line !~ '\<\%(fi\|esac\|done\|end\)\>\s*\%(#.*\)\=$'
       let ind += s:indent_value('default')
     endif


### PR DESCRIPTION
Hello! Currently the regex that matches reserved keywords in zsh also matches words ending in those keywords. For eg: statements like `sudo chattr +i xxx` or `mycase` will match and cause the subsequent statements to indent incorrectly. This pr attempts to fix that by making the regex match the whole word instead. Please let me know if this works or if you have any questions. Thank you.