### PR TITLE
Update sh.vim

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -115,7 +115,7 @@ function! GetShIndent()
   " Current line is a endif line, so get indent from start of "if condition" line
   " TODO: should we do the same for other "end" lines?
   if curline =~ '^\s*\%(fi\)\s*\%(#.*\)\=$'
-    let previous_line = search('if.\{-\};\s*then\s*\%(#.*\)\=$', 'bnW')
+    let previous_line = searchpair('\<if\>', '', '\<fi\>', 'bnW')
     if previous_line > 0
       let ind = indent(previous_line)
     endif


### PR DESCRIPTION
I noticed that the bash indentation is broken, specifically in the closing 'fi'.  My understanding of the code is that it is excluding nested 'if' statements.  I have tested particular 'if'/'fi' nested indentations and my fix seems to do it.  I don't think there are any side effects, at least not yet.