### PR TITLE
Fix 'fi' indentation

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -134,7 +134,7 @@ function! GetShIndent()
   " TODO: should we do the same for other "end" lines?
   if curline =~ '^\s*\%(fi\);\?\s*\%(#.*\)\=$'
     let ind = indent(v:lnum)
-    let previous_line = searchpair('\<if\>', '', '\<fi\>\zs', 'bnW', 'synIDattr(synID(line("."),col("."), 1),"name") =~? "comment\\|quote"')
+    let previous_line = searchpair('^\s*\<if\>', '', '\<fi\>\zs', 'bnW', 'synIDattr(synID(line("."),col("."), 1),"name") =~? "comment\\|quote"')
     if previous_line > 0
       let ind = indent(previous_line)
     endif

--- a/test/13/cmd.sh
+++ b/test/13/cmd.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+vim --clean \
+    -c ':unlet! b:did_indent' \
+    -c ':delfunc! GetShIndent' \
+    -c ':so ../../indent/sh.vim' \
+    -c ':set sw=0 sts=-1 ts=2 et' \
+    -c ':5' \
+    -c 'norm! ciwfi' \
+    -c ':saveas! output.sh' \
+    -c ':q!' indent.sh

--- a/test/13/indent.sh
+++ b/test/13/indent.sh
@@ -1,0 +1,3 @@
+if a; then
+    b if
+fi

--- a/test/13/reference.sh
+++ b/test/13/reference.sh
@@ -1,0 +1,3 @@
+if a; then
+    b if
+fi


### PR DESCRIPTION
- In the case of commands inside of the `if/else ..  fi` blocks with
  'if' arguments the indentation works wrong. Fix it.

- Add test for this indentation problem.

For example, the indentation in the following code snippet

```sh
if :; then
  dd if=/dev/zero of=/dev/null
  fi
```

would be fixed with this commit

```sh
if :; then
  dd if=/dev/zero of=/dev/null
fi
```