### PR TITLE
Fix issue #25 - stricter matching of indention keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/test/*/output.sh

--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -84,8 +84,8 @@ function! GetShIndent()
 
   " Check contents of previous lines
   " should not apply to e.g. commented lines
-  if line =~ '^\s*\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>' ||
-        \  (&ft is# 'zsh' && line =~ '^\s*\<\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>')
+  if line =~ '^\s*\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>\($\|\s\)' ||
+        \  (&ft is# 'zsh' && line =~ '^\s*\<\%(if\|then\|do\|else\|elif\|case\|while\|until\|for\|select\|foreach\)\>\($\|\s\)')
     if !s:is_end_expression(line)
       let ind += s:indent_value('default')
     endif

--- a/test/15/cmd.sh
+++ b/test/15/cmd.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+vim --clean \
+    -c ':unlet! b:did_indent' \
+    -c ':delfunc! GetShIndent' \
+    -c ':so ../../indent/sh.vim' \
+    -c ':set sw=0 sts=-1 ts=2 et' \
+    -c 'norm! gg=G' \
+    -c ':saveas! output.sh' \
+    -c ':q!' indent.sh

--- a/test/15/indent.sh
+++ b/test/15/indent.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+f(){
+for fn in a b c
+do
+for-script $fn
+done
+}

--- a/test/15/reference.sh
+++ b/test/15/reference.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+f(){
+  for fn in a b c
+  do
+    for-script $fn
+  done
+}


### PR DESCRIPTION
This fix prevents matching words such as `for-ever` `if.nope` `case:dismissed` as indention starting keywords.
