### PR TITLE
Fix issue #33 - Test 01 fails

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -120,7 +120,7 @@ function! GetShIndent()
     while !s:is_empty(getline(i)) && i > pnum
       let i -= 1
     endw
-    if i == pnum && s:is_continuation_line(line)
+    if i == pnum && (s:is_continuation_line(line) || pline =~ '{\s*\(#.*\)\=$')
       let ind += ind2
     else
       let ind = ind2


### PR DESCRIPTION
In addition to the `line` also check `pline` for '{'.

Fixes: 6945e915 ("Fix line indent after a last continuation line")