### PR TITLE
Fix indent for local arrays, also fixed arrays set with typeset and declare prefix

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -7,6 +7,7 @@
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20250318  - Detect local arrays in functions
 "          20241411  - Detect dash character in function keyword for
 "                      bash mode (issue #16049)
 "          20190726  - Correctly skip if keywords in syntax comments
@@ -218,7 +219,7 @@ function! s:is_function_definition(line)
 endfunction
 
 function! s:is_array(line)
-  return a:line =~ '^\s*\(local\s*\)\?\<\k\+\>=('
+  return a:line =~ '^\s*\(local\s\+\)\?\<\k\+\>=('
 endfunction
 
 function! s:is_in_block(line)

--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -219,7 +219,7 @@ function! s:is_function_definition(line)
 endfunction
 
 function! s:is_array(line)
-  return a:line =~ '^\s*\(local\s\+\)\?\<\k\+\>=('
+  return a:line =~ '^\s*\(\(declare\|typeset\|local\)\s\+\(-[Aalrtu]\+\s\+\)\?\)\?\<\k\+\>=('
 endfunction
 
 function! s:is_in_block(line)

--- a/test/22/cmd.sh
+++ b/test/22/cmd.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+vim --clean \
+    -c ':unlet! b:did_indent' \
+    -c ':delfunc! GetShIndent' \
+    -c ':so ../../indent/sh.vim' \
+    -c ':set sw=0 sts=-1 ts=2 et' \
+    -c 'norm! gg=G' \
+    -c ':saveas! output.sh' \
+    -c ':q!' indent.sh

--- a/test/22/indent.sh
+++ b/test/22/indent.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+function variables(){
+local test1="test1"
+test2=(
+"test" "test2"
+)
+local test3=(
+"test" "test3"
+)
+}

--- a/test/22/indent.sh
+++ b/test/22/indent.sh
@@ -9,4 +9,11 @@ test2=(
 local test3=(
 "test" "test3"
 )
+typeset -ua test4=(
+"test" "test4"
+)
+declare -a inline=("also work") multiline=(
+"multiple" "values"
+)
+declare -l var="VALUE"
 }

--- a/test/22/reference.sh
+++ b/test/22/reference.sh
@@ -9,4 +9,11 @@ function variables(){
   local test3=(
     "test" "test3"
   )
+  typeset -ua test4=(
+    "test" "test4"
+  )
+  declare -a inline=("also work") multiline=(
+    "multiple" "values"
+  )
+  declare -l var="VALUE"
 }

--- a/test/22/reference.sh
+++ b/test/22/reference.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+function variables(){
+  local test1="test1"
+  test2=(
+    "test" "test2"
+  )
+  local test3=(
+    "test" "test3"
+  )
+}


### PR DESCRIPTION
Currently, multiline local arrays in the vim repository are not properly indented, and the closing parenthesis within a function breaks the indentation.

i've noticed the check just for local arrays was already fixed in this repo.

code in vim-sh-indent repo before this MR:
```return a:line =~ '^\s*\(local\s*\)\?\<\k\+\>=('```

code in vim repo at this moment:
```return a:line =~ '^\s*\<\k\+\>=('```

Fixes of this MR:
- Updated the regular expression in the is_array function to optionally match the local, declare and typeset keyword.
- Added test cases to cover functions containing local strings, global arrays, local arrays, typeset arrays and declare arrays.

Thanks [@e-kwsm](https://github.com/e-kwsm) for providing the regex for arrays with prefix typeset and declare.

More Information in the original MR in the vim repo:
https://github.com/vim/vim/pull/16930