### PR TITLE
add fix for closing functions after multiline commands

### DIFF
--- a/indent/sh.vim
+++ b/indent/sh.vim
@@ -7,6 +7,7 @@
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20250906  - indent function closing properly on multiline commands
 "          20250318  - Detect local arrays in functions
 "          20241411  - Detect dash character in function keyword for
 "                      bash mode (issue #16049)
@@ -183,6 +184,15 @@ function! GetShIndent()
     else
       " use indent of current line
       return indent(v:lnum)
+    endif
+  endif
+
+  " Special case: if the current line is a closing '}', align with matching '{'
+  if curline =~ '^\s*}\s*$'
+    let match_lnum = searchpair('{', '', '}', 'bnW',
+      \ 'synIDattr(synID(line("."),col("."), 1),"name") =~? "comment\\|quote"')
+    if match_lnum > 0
+      return indent(match_lnum)
     endif
   endif
 

--- a/test/23/cmd.sh
+++ b/test/23/cmd.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+vim --clean \
+    -c ':unlet! b:did_indent' \
+    -c ':delfunc! GetShIndent' \
+    -c ':so ../../indent/sh.vim' \
+    -c ':set sw=0 sts=-1 ts=2 et' \
+    -c 'norm! gg=G' \
+    -c ':saveas! output.sh' \
+    -c ':q!' indent.sh

--- a/test/23/indent.sh
+++ b/test/23/indent.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+function lastLineEmptyInFunctionAfterContinuation() {
+[[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+&& echo "show help" && exit
+
+}
+
+function lastLineCommentAfterContinuation() {
+[[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+&& echo "show help" && exit
+# if last line is not a continuation, but a comment, it should indent correctly
+}
+
+function lastLineClosingAfterContinuation() {
+[[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+&& echo "show help" && exit
+}
+
+function lastLineClosingAfterContinuationWithComment() {
+# Test Comment
+[[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+&& echo "show help" && exit
+}
+
+echo "test multiline without function" \
+&& echo "should be indented"
+echo "should not be indented"

--- a/test/23/reference.sh
+++ b/test/23/reference.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+function lastLineEmptyInFunctionAfterContinuation() {
+  [[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+    && echo "show help" && exit
+
+}
+
+function lastLineCommentAfterContinuation() {
+  [[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+    && echo "show help" && exit
+  # if last line is not a continuation, but a comment, it should indent correctly
+}
+
+function lastLineClosingAfterContinuation() {
+  [[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+    && echo "show help" && exit
+}
+
+function lastLineClosingAfterContinuationWithComment() {
+  # Test Comment
+  [[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
+    && echo "show help" && exit
+}
+
+echo "test multiline without function" \
+  && echo "should be indented"
+echo "should not be indented"


### PR DESCRIPTION
Hi @chrisbra ,
i had some issues indenting code especially within functions when using commands over multiple lines.

Example of unpatched behavior:
```bash
function checkArgs() {
	[[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
		&& echo "usage: ./dnschk.sh domainname.de" && exit
	}
```

expected:
```bash
function checkArgs() {
	[[ "$#" != "1" || "$1" = "-h" || "$1" = "--help" ]] \
		&& echo "usage: ./dnschk.sh domainname.de" && exit
}
```

I've added some examples in a test and all other tests also pass.
There is no strange behavior that I've noticed (tested this also on a few real world examples).
sadly this patch doesn't seem to fix other issues with functions / curly braces, guess these would need more time.